### PR TITLE
chore: bump number of orders per page

### DIFF
--- a/tap_shiphero/gql_queries/orders.graphql
+++ b/tap_shiphero/gql_queries/orders.graphql
@@ -2,7 +2,7 @@ query {
     orders (updated_from: $updated_from) {
         request_id
         complexity
-        data(first: 50, after: $cursor) {
+        data(first: 95, after: $cursor) {
             pageInfo {
                 hasNextPage
                 hasPreviousPage


### PR DESCRIPTION
Speed up sync while also staying beneath rate limit quota.